### PR TITLE
support setting prerelease number

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ may be added to the version using the `--pre` and `--build` parameters. If the
 `--name` parameter is specified then that will be used instead of the default
 `pre`. If the same prerelease name is used multiple times the prerelease number
 will be incremented and it defaults to `0` if set initially or changed to a new
-name.
+name. If the argument `--value` is set then the prerelease number will be
+specifically set to the value provided.
 
 `none` can be used to synchronize new or out of sync files with post hooks, and
 also it can be used in conjunction with `--pre` and `--build` without
@@ -119,8 +120,13 @@ semver inc major # 2.0.0
 ```sh
 semver set 1.2.3-pre.0
 semver inc --pre              # 1.2.3-pre.1
+semver inc --pre --value 10   # 1.2.3-pre.10
 semver inc --pre --name alpha # 1.2.3-alpha.0
-semver inc --pre --build 1    # 1.2.3-alpha.1+1
+semver inc --build 1          # 1.2.3-alpha.1+1
+semver inc --pre \
+  --name alpha \
+  --value 11 \
+  --build abc123              # 1.2.3-alpha.11+abc123
 ```
 
 ### Increment Post Hooks

--- a/src/commands/get.ts
+++ b/src/commands/get.ts
@@ -27,8 +27,8 @@ const prereleaseValueOption = {
   alias: "v",
   type: "number",
   description: "Prerelease number value",
-  default: undefined
-}
+  default: undefined,
+};
 
 export const get = {
   command: "get",

--- a/src/commands/get.ts
+++ b/src/commands/get.ts
@@ -23,6 +23,13 @@ const prereleaseNameOption = {
   default: "pre",
 };
 
+const prereleaseValueOption = {
+  alias: "v",
+  type: "number",
+  description: "Prerelease number value",
+  default: undefined
+}
+
 export const get = {
   command: "get",
   describe: "Get the version",
@@ -31,6 +38,7 @@ export const get = {
       .option("build", buildOption)
       .option("pre", prereleaseOption)
       .option("name", prereleaseNameOption)
+      .option("value", prereleaseValueOption)
       .command(major)
       .command(minor)
       .command(patch)

--- a/src/commands/get/major.ts
+++ b/src/commands/get/major.ts
@@ -7,12 +7,13 @@ export const major = {
   command: "major",
   describe: "A major version increment",
   handler: async (args: Arguments & IContext) => {
-    const { pre, name, build } = args;
+    const { pre, name = "pre", value, build } = args;
     const version = await readVersionFile();
     const { current } = increment({
       kind: IncrementKind.Major,
       version,
       pre: pre ? name : undefined,
+      value,
       build,
     });
     await printVersion(args, current);

--- a/src/commands/get/minor.ts
+++ b/src/commands/get/minor.ts
@@ -7,12 +7,13 @@ export const minor = {
   command: "minor",
   describe: "A minor version increment",
   handler: async (args: Arguments & IContext) => {
-    const { pre, name, build } = args;
+    const { pre, name, value, build } = args;
     const version = await readVersionFile();
     const { current } = increment({
       kind: IncrementKind.Minor,
       version,
       pre: pre ? name : undefined,
+      value,
       build,
     });
     await printVersion(args, current);

--- a/src/commands/get/none.ts
+++ b/src/commands/get/none.ts
@@ -7,12 +7,13 @@ export const none = {
   command: ["none", "$0"],
   describe: "Gets the version",
   handler: async (args: Arguments & IContext) => {
-    const { pre, name, build } = args;
+    const { pre, name, value, build } = args;
     const version = await readVersionFile();
     const { current } = increment({
       kind: IncrementKind.None,
       version,
       pre: pre ? name : undefined,
+      value,
       build,
     });
     await printVersion(args, current);

--- a/src/commands/get/patch.ts
+++ b/src/commands/get/patch.ts
@@ -7,12 +7,13 @@ export const patch = {
   command: "patch",
   describe: "A patch version increment",
   handler: async (args: Arguments & IContext) => {
-    const { pre, name, build } = args;
+    const { pre, name, value, build } = args;
     const version = await readVersionFile();
     const { current } = increment({
       kind: IncrementKind.Patch,
       version,
       pre: pre ? name : undefined,
+      value,
       build,
     });
     await printVersion(args, current);

--- a/src/commands/inc.ts
+++ b/src/commands/inc.ts
@@ -22,6 +22,14 @@ const prereleaseNameOption = {
   example: "alpha",
   default: "pre",
 };
+
+const prereleaseValueOption = {
+  alias: "v",
+  type: "number",
+  description: "Prerelease number value",
+  default: undefined
+}
+
 export const inc = {
   command: "inc",
   describe: "Increment the version",
@@ -30,6 +38,7 @@ export const inc = {
       .option("build", buildOption)
       .option("pre", prereleaseOption)
       .option("name", prereleaseNameOption)
+      .option("value", prereleaseValueOption)
       .command(major)
       .command(minor)
       .command(patch)

--- a/src/commands/inc.ts
+++ b/src/commands/inc.ts
@@ -27,8 +27,8 @@ const prereleaseValueOption = {
   alias: "v",
   type: "number",
   description: "Prerelease number value",
-  default: undefined
-}
+  default: undefined,
+};
 
 export const inc = {
   command: "inc",

--- a/src/commands/inc/major.test.ts
+++ b/src/commands/inc/major.test.ts
@@ -68,4 +68,37 @@ describe("major", () => {
       args: ["VERSION", "2.0.0+1\n"],
     });
   });
+  it("major04", async () => {
+    await major.handler(
+      {
+        _: [],
+        pre: true,
+        name: "pre",
+        value: "7",
+      } as unknown as Arguments & IContext,
+    );
+    assertSpyCall(ctx0.consoleLog, 0, {
+      args: ["2.0.0-pre.7"],
+    });
+    assertSpyCall(ctx0.writeTextFile, 0, {
+      args: ["VERSION", "2.0.0-pre.7\n"],
+    });
+  });
+  it("major05", async () => {
+    await major.handler(
+      {
+        _: [],
+        pre: true,
+        name: "pre",
+        value: "7",
+        build: "abc123",
+      } as unknown as Arguments & IContext,
+    );
+    assertSpyCall(ctx0.consoleLog, 0, {
+      args: ["2.0.0-pre.7+abc123"],
+    });
+    assertSpyCall(ctx0.writeTextFile, 0, {
+      args: ["VERSION", "2.0.0-pre.7+abc123\n"],
+    });
+  });
 });

--- a/src/commands/inc/major.ts
+++ b/src/commands/inc/major.ts
@@ -12,12 +12,13 @@ export const major = {
   command: "major",
   describe: "A major version increment",
   handler: async (args: Arguments & IContext) => {
-    const { pre, name, build } = args;
+    const { pre, name, value, build } = args;
     const version = await readVersionFile();
     const { previous, current } = increment({
       kind: IncrementKind.Major,
       version,
       pre: pre ? name : undefined,
+      value,
       build,
     });
     await writeVersionFile(current);

--- a/src/commands/inc/minor.test.ts
+++ b/src/commands/inc/minor.test.ts
@@ -80,4 +80,39 @@ describe("minor", () => {
       args: ["VERSION", "1.3.0+1\n"],
     });
   });
+  it("minor04", async () => {
+    await minor.handler(
+      {
+        ...context,
+        _: [],
+        pre: true,
+        name: "pre",
+        value: "7",
+      } as Arguments & IContext,
+    );
+    assertSpyCall(ctx0.consoleLog, 0, {
+      args: ["1.3.0-pre.7"],
+    });
+    assertSpyCall(ctx0.writeTextFile, 0, {
+      args: ["VERSION", "1.3.0-pre.7\n"],
+    });
+  });
+  it("minor05", async () => {
+    await minor.handler(
+      {
+        ...context,
+        _: [],
+        pre: true,
+        name: "pre",
+        value: "7",
+        build: "abc123",
+      } as Arguments & IContext,
+    );
+    assertSpyCall(ctx0.consoleLog, 0, {
+      args: ["1.3.0-pre.7+abc123"],
+    });
+    assertSpyCall(ctx0.writeTextFile, 0, {
+      args: ["VERSION", "1.3.0-pre.7+abc123\n"],
+    });
+  });
 });

--- a/src/commands/inc/minor.ts
+++ b/src/commands/inc/minor.ts
@@ -12,12 +12,13 @@ export const minor = {
   command: "minor",
   describe: "A minor version increment",
   handler: async (args: Arguments & IContext) => {
-    const { pre, name, build } = args;
+    const { pre, name, value, build } = args;
     const version = await readVersionFile();
     const { previous, current } = increment({
       kind: IncrementKind.Minor,
       version,
       pre: pre ? name : undefined,
+      value,
       build,
     });
     await writeVersionFile(current);

--- a/src/commands/inc/none.test.ts
+++ b/src/commands/inc/none.test.ts
@@ -68,4 +68,37 @@ describe("none", () => {
       args: ["VERSION", "1.2.3+1\n"],
     });
   });
+  it("none03", async () => {
+    await none.handler(
+      {
+        _: [],
+        pre: true,
+        name: "pre",
+        value: "7",
+      } as unknown as Arguments & IContext,
+    );
+    assertSpyCall(ctx0.consoleLog, 0, {
+      args: ["1.2.3-pre.7"],
+    });
+    assertSpyCall(ctx0.writeTextFile, 0, {
+      args: ["VERSION", "1.2.3-pre.7\n"],
+    });
+  });
+  it("none04", async () => {
+    await none.handler(
+      {
+        _: [],
+        pre: true,
+        name: "pre",
+        value: "7",
+        build: "abc.123",
+      } as unknown as Arguments & IContext,
+    );
+    assertSpyCall(ctx0.consoleLog, 0, {
+      args: ["1.2.3-pre.7+abc.123"],
+    });
+    assertSpyCall(ctx0.writeTextFile, 0, {
+      args: ["VERSION", "1.2.3-pre.7+abc.123\n"],
+    });
+  });
 });

--- a/src/commands/inc/none.ts
+++ b/src/commands/inc/none.ts
@@ -12,12 +12,13 @@ export const none = {
   command: ["none", "$0"],
   describe: "A none version increment",
   handler: async (args: Arguments & IContext) => {
-    const { pre, name, build } = args;
+    const { pre, name, value, build } = args;
     const version = await readVersionFile();
     const { previous, current } = increment({
       kind: IncrementKind.None,
       version,
       pre: pre ? name : undefined,
+      value,
       build,
     });
     await writeVersionFile(current);

--- a/src/commands/inc/patch.test.ts
+++ b/src/commands/inc/patch.test.ts
@@ -54,7 +54,7 @@ describe("patch", () => {
       args: ["VERSION", "1.2.4-pre.0\n"],
     });
   });
-  it("patch01", async () => {
+  it("patch02", async () => {
     await patch.handler(
       {
         _: [],
@@ -66,6 +66,39 @@ describe("patch", () => {
     });
     assertSpyCall(ctx0.writeTextFile, 0, {
       args: ["VERSION", "1.2.4+1\n"],
+    });
+  });
+  it("patch03", async () => {
+    await patch.handler(
+      {
+        _: [],
+        pre: true,
+        name: "pre",
+        value: "7",
+      } as unknown as Arguments & IContext,
+    );
+    assertSpyCall(ctx0.consoleLog, 0, {
+      args: ["1.2.4-pre.7"],
+    });
+    assertSpyCall(ctx0.writeTextFile, 0, {
+      args: ["VERSION", "1.2.4-pre.7\n"],
+    });
+  });
+  it("patch04", async () => {
+    await patch.handler(
+      {
+        _: [],
+        pre: true,
+        name: "pre",
+        value: "7",
+        build: "abc.123",
+      } as unknown as Arguments & IContext,
+    );
+    assertSpyCall(ctx0.consoleLog, 0, {
+      args: ["1.2.4-pre.7+abc.123"],
+    });
+    assertSpyCall(ctx0.writeTextFile, 0, {
+      args: ["VERSION", "1.2.4-pre.7+abc.123\n"],
     });
   });
 });

--- a/src/commands/inc/patch.ts
+++ b/src/commands/inc/patch.ts
@@ -12,12 +12,13 @@ export const patch = {
   command: "patch",
   describe: "A patch version increment",
   handler: async (args: Arguments & IContext) => {
-    const { pre, name, build } = args;
+    const { pre, name, value, build } = args;
     const version = await readVersionFile();
     const { previous, current } = increment({
       kind: IncrementKind.Patch,
       version,
       pre: pre ? name : undefined,
+      value,
       build,
     });
     await writeVersionFile(current);

--- a/src/util/increment.ts
+++ b/src/util/increment.ts
@@ -12,34 +12,47 @@ export type IncrementOptions = {
   version: string | SemVer;
   kind: IncrementKind;
   pre?: string;
+  value?: string;
   build?: string;
 };
 
 export function increment(options: IncrementOptions) {
-  const { kind, version, pre, build } = options;
+  const { kind, version, pre, value, build } = options;
   const semver = parse(version);
   if (!semver) {
     throw new InvalidVersionError(version.toString());
   }
-
   return {
     previous: semver,
     current: (() => {
       switch (kind) {
         case IncrementKind.Major:
-          return pre
-            ? semver.increment("premajor", pre, build)
-            : semver.increment("major", undefined, build);
+          return pre && value
+            ? (semver.increment("major", undefined, build), semver.prerelease = [...pre.split("."), parseInt(value)], semver)
+            : pre
+              ? semver.increment("premajor", pre, build)
+              : semver.increment("major", undefined, build);
         case IncrementKind.Minor:
-          return pre
-            ? semver.increment("preminor", pre, build)
-            : semver.increment("minor", undefined, build);
+          return pre && value !== undefined
+            ? (semver.increment("minor", undefined, build), semver.prerelease = [...pre.split("."), parseInt(value)], semver)
+            : pre
+              ? semver.increment("preminor", pre, build)
+              : semver.increment("minor", undefined, build);
         case IncrementKind.Patch:
-          return pre
-            ? semver.increment("prepatch", pre, build)
-            : semver.increment("patch", undefined, build);
+          return pre && value
+            ? (semver.increment("patch", undefined, build), semver.prerelease = [...pre.split("."), parseInt(value)], semver)
+            : pre
+              ? semver.increment("prepatch", pre, build)
+              : semver.increment("patch", undefined, build);
         case IncrementKind.None: {
-          if (pre) {
+          if (pre && value && build != undefined) {
+            semver.prerelease = [...pre.split("."), parseInt(value)]
+            semver.build = build.split(".").map((b) => b.trim());
+            return semver
+          } else if (pre && value) {
+            semver.prerelease = [...pre.split("."), parseInt(value)]
+            return semver
+          } else if (pre) {
             return semver.increment("pre", pre, build);
           } else if (build !== undefined) {
             semver.build = build.split(".").map((b) => b.trim());

--- a/src/util/increment.ts
+++ b/src/util/increment.ts
@@ -28,30 +28,36 @@ export function increment(options: IncrementOptions) {
       switch (kind) {
         case IncrementKind.Major:
           return pre && value
-            ? (semver.increment("major", undefined, build), semver.prerelease = [...pre.split("."), parseInt(value)], semver)
+            ? (semver.increment("major", undefined, build),
+              semver.prerelease = [...pre.split("."), parseInt(value)],
+              semver)
             : pre
-              ? semver.increment("premajor", pre, build)
-              : semver.increment("major", undefined, build);
+            ? semver.increment("premajor", pre, build)
+            : semver.increment("major", undefined, build);
         case IncrementKind.Minor:
           return pre && value !== undefined
-            ? (semver.increment("minor", undefined, build), semver.prerelease = [...pre.split("."), parseInt(value)], semver)
+            ? (semver.increment("minor", undefined, build),
+              semver.prerelease = [...pre.split("."), parseInt(value)],
+              semver)
             : pre
-              ? semver.increment("preminor", pre, build)
-              : semver.increment("minor", undefined, build);
+            ? semver.increment("preminor", pre, build)
+            : semver.increment("minor", undefined, build);
         case IncrementKind.Patch:
           return pre && value
-            ? (semver.increment("patch", undefined, build), semver.prerelease = [...pre.split("."), parseInt(value)], semver)
+            ? (semver.increment("patch", undefined, build),
+              semver.prerelease = [...pre.split("."), parseInt(value)],
+              semver)
             : pre
-              ? semver.increment("prepatch", pre, build)
-              : semver.increment("patch", undefined, build);
+            ? semver.increment("prepatch", pre, build)
+            : semver.increment("patch", undefined, build);
         case IncrementKind.None: {
           if (pre && value && build != undefined) {
-            semver.prerelease = [...pre.split("."), parseInt(value)]
+            semver.prerelease = [...pre.split("."), parseInt(value)];
             semver.build = build.split(".").map((b) => b.trim());
-            return semver
+            return semver;
           } else if (pre && value) {
-            semver.prerelease = [...pre.split("."), parseInt(value)]
-            return semver
+            semver.prerelease = [...pre.split("."), parseInt(value)];
+            return semver;
           } else if (pre) {
             return semver.increment("pre", pre, build);
           } else if (build !== undefined) {


### PR DESCRIPTION
## Proposed changes

This adds the ability to set the prerelease number specifically during a `get` or `inc` command. If not specified it will attempt to increment the prerelease number or set it to the default `0` but if you now specify `--value $N` then it will specifically set it to `N`

For example if your current version is `1.2.3`, the following behaviors are expected when incrementing now:

| args | incremented version |
| ---- | -------------------- |
|   | `1.2.3` |
| `--pre` | `1.2.3-pre.0` |
| `--pre --name alpha` | `1.2.3-alpha.0` |
| `--pre --name alpha --value 11` | `1.2.3-alpha.11` |

## Types of changes

Additive, non-breaking feature. `minor` increment.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

- [x] I have read the
      [CONTRIBUTING](https://github.com/Optum/semver-cli/blob/main/CONTRIBUTING.md)
      doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
