### PR TITLE
fix the deno land url

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Installation from source will require
 #### module
 
 ```sh
-deno install -A https://deno.land/x/semver-cli@0.5.0/main.ts -n semver
+deno install -A https://deno.land/x/semver_cli@0.5.0/main.ts -n semver
 ```
 
 ### git


### PR DESCRIPTION
## Proposed changes

The url on the main readme isn't quite right, it should be `semver_cli` not `semver-cli`. Deno Land doesn't support `-` in module names.
