### PR TITLE
Adding optional format input for the patch hook

### DIFF
--- a/src/commands/set.test.ts
+++ b/src/commands/set.test.ts
@@ -161,6 +161,7 @@ describe("set", () => {
         args: [
           "src/test.csproj",
           parse("1.2.3"),
+          undefined,
         ],
       });
     });
@@ -184,6 +185,7 @@ describe("set", () => {
         args: [
           "src/test.csproj",
           parse("1.0.0"),
+          undefined
         ],
       });
     });

--- a/src/commands/set.test.ts
+++ b/src/commands/set.test.ts
@@ -185,7 +185,7 @@ describe("set", () => {
         args: [
           "src/test.csproj",
           parse("1.0.0"),
-          undefined
+          undefined,
         ],
       });
     });

--- a/src/context.ts
+++ b/src/context.ts
@@ -12,7 +12,11 @@ export interface IContext {
   config?: string;
   githubDir: string;
   hooks: {
-    patch: (file: string, current: SemVer) => Promise<void>;
+    patch: (
+      file: string,
+      current: SemVer,
+      format?: FormatKind,
+    ) => Promise<void>;
     replace: (
       file: string,
       previous: SemVer,

--- a/src/hooks/hooks.interfaces.ts
+++ b/src/hooks/hooks.interfaces.ts
@@ -13,6 +13,7 @@ export type ReplacePostHook = {
 export type PatchPostHook = {
   kind: PostHookKind.Patch;
   file: string;
+  format?: FormatKind;
 };
 export type RegExpPostHook = {
   kind: PostHookKind.RegExp;

--- a/src/hooks/patch.test.ts
+++ b/src/hooks/patch.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from "testing/bdd";
 import { assertSpyCall, stub } from "testing/mock";
 import { parse } from "semver";
 import { patch } from "./patch.ts";
+import { FormatKind } from "../util/variant.ts";
 
 describe("patch", () => {
   it("should log formatted version string for csproj", async () => {
@@ -58,6 +59,39 @@ describe("patch", () => {
       // Verify console.log was called with formatted string, not [object Object]
       assertSpyCall(consoleLogStub, 0, {
         args: ["patching 1.2.3 in package.json"],
+      });
+    } finally {
+      consoleLogStub.restore();
+      readTextFileStub.restore();
+      writeTextFileStub.restore();
+      statStub.restore();
+    }
+  });
+
+  it("should log formatted Docker version string for Chart.yaml", async () => {
+    const consoleLogStub = stub(console, "log");
+    const readTextFileStub = stub(
+      Deno,
+      "readTextFile",
+      () => Promise.resolve("apiVersion: v2\nname: test-app\nversion: 1.0.0"),
+    );
+    const writeTextFileStub = stub(
+      Deno,
+      "writeTextFile",
+      () => Promise.resolve(),
+    );
+    const statStub = stub(
+      Deno,
+      "stat",
+      () => Promise.reject(new Deno.errors.NotFound()),
+    );
+
+    try {
+      await patch("Chart.yaml", parse("1.2.3-pr.4+5")!, FormatKind.Docker);
+
+      // Verify console.log was called with formatted string, not [object Object]
+      assertSpyCall(consoleLogStub, 0, {
+        args: ["patching 1.2.3-pr.4-5 in Chart.yaml"],
       });
     } finally {
       consoleLogStub.restore();

--- a/src/hooks/patch.ts
+++ b/src/hooks/patch.ts
@@ -1,67 +1,85 @@
 import * as path from "path";
 import { applyEdits, modify } from "jsonc-parser";
 import { UnsupportedFileKindError } from "../errors/mod.ts";
-import { semverFormats } from "../util/variant.ts";
+import { FormatKind, semverFormats } from "../util/variant.ts";
 import { exists } from "../util/exists.ts";
-import { format, SemVer } from "semver";
+import { SemVer } from "semver";
 
 export async function patch(
   file: string,
   version: SemVer,
+  format?: FormatKind,
 ) {
-  console.log(`patching ${format(version)} in ${file}`);
   const ext = path.extname(file);
   const fileName = path.basename(file);
   if (ext === ".csproj" || ext === ".targets") {
-    await patchCsproj(file, version);
+    await patchCsproj(file, version, format);
   } else if (fileName === "package.json") {
-    await patchPackageJson(file, version);
-    await patchPackageLockJson(file, version);
+    await patchPackageJson(file, version, format);
+    await patchPackageLockJson(file, version, format);
   } else if (fileName === "Chart.yaml") {
-    await patchChartYaml(file, version);
+    await patchChartYaml(file, version, format);
   } else if (fileName === "pom.xml") {
-    await patchPomXml(file, version);
+    await patchPomXml(file, version, format);
   } else {
     throw new UnsupportedFileKindError(file);
   }
 }
 
-async function patchCsproj(file: string, version: SemVer) {
-  const { dotnet } = semverFormats(version);
+async function patchCsproj(file: string, version: SemVer, format?: FormatKind) {
+  const formats = semverFormats(version);
+  const newVersion = formats[format ?? FormatKind.Dotnet];
+  console.log(`patching ${newVersion} in ${file}`);
+
   const contents = await Deno.readTextFile(file);
   const r =
     /(?<=<Project.*>(.|\n)*<PropertyGroup>(.|\n)*<Version>).*(?=<\/Version>)/;
-  const updated = contents.replace(r, dotnet);
+  const updated = contents.replace(r, newVersion);
   await Deno.writeTextFile(file, updated);
 }
 
-async function patchPomXml(file: string, version: SemVer) {
-  const { original } = semverFormats(version);
+async function patchPomXml(file: string, version: SemVer, format?: FormatKind) {
+  const formats = semverFormats(version);
+  const newVersion = formats[format ?? FormatKind.Original];
+  console.log(`patching ${newVersion} in ${file}`);
+
   const contents = await Deno.readTextFile(file);
   const r = /(?<=<project>(.|\n)*<version>).*(?=<\/version>)/;
-  const updated = contents.replace(r, original);
+  const updated = contents.replace(r, newVersion);
   await Deno.writeTextFile(file, updated);
 }
 
-async function patchPackageJson(file: string, version: SemVer) {
-  const { original } = semverFormats(version);
+async function patchPackageJson(
+  file: string,
+  version: SemVer,
+  format?: FormatKind,
+) {
+  const formats = semverFormats(version);
+  const newVersion = formats[format ?? FormatKind.Original];
+  console.log(`patching ${newVersion} in ${file}`);
+
   const contents = await Deno.readTextFile(file);
-  const edits = modify(contents, ["version"], original, {});
+  const edits = modify(contents, ["version"], newVersion, {});
   const result = applyEdits(contents, edits);
   await Deno.writeTextFile(file, result);
 }
 
-async function patchPackageLockJson(packageJsonPath: string, version: SemVer) {
-  const { original } = semverFormats(version);
+async function patchPackageLockJson(
+  packageJsonPath: string,
+  version: SemVer,
+  format?: FormatKind,
+) {
+  const formats = semverFormats(version);
+  const newVersion = formats[format ?? FormatKind.Original];
   const dir = path.dirname(packageJsonPath);
   const packageLockJsonPath = path.resolve(dir, "package-lock.json");
   if (await exists(packageLockJsonPath)) {
     const contents = await Deno.readTextFile(packageLockJsonPath);
-    const versionEdits = modify(contents, ["version"], original, {});
+    const versionEdits = modify(contents, ["version"], newVersion, {});
     const moduleVersionEdits = modify(
       contents,
       ["packages", "", "version"],
-      original,
+      newVersion,
       {},
     );
     const edits = [...versionEdits, ...moduleVersionEdits];
@@ -70,12 +88,19 @@ async function patchPackageLockJson(packageJsonPath: string, version: SemVer) {
   }
 }
 
-async function patchChartYaml(file: string, version: SemVer) {
-  const { original } = semverFormats(version);
+async function patchChartYaml(
+  file: string,
+  version: SemVer,
+  format?: FormatKind,
+) {
+  const formats = semverFormats(version);
+  const newVersion = formats[format ?? FormatKind.Original];
+  console.log(`patching ${newVersion} in ${file}`);
+
   const contents = await Deno.readTextFile(file);
   const result = contents.replace(
     /^version:\s*(.*)$/m,
-    `version: ${original}`,
+    `version: ${newVersion}`,
   );
   await Deno.writeTextFile(file, result);
 }

--- a/src/hooks/post.ts
+++ b/src/hooks/post.ts
@@ -34,7 +34,7 @@ export async function postVersionHook(
           await context.hooks.replace(hook.file, previous, current);
           break;
         case PostHookKind.Patch:
-          await context.hooks.patch(hook.file, current);
+          await context.hooks.patch(hook.file, current, hook.format);
           break;
         case PostHookKind.RegExp:
           await context.hooks.regexp(


### PR DESCRIPTION
## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.

OCI is the modern approach for deploying Helm charts and require Docker-like formatting on the Semver versions. With the default + in a prerelease version, Helm will rewrite the + to an _, but the chart still gets referenced by the + sign. To prevent confusion in the syntax, this PR adds the format input as an optional parameter for the patch hook. All original default settings exist, but now the user can define the a different format for these specialized files.

Below is a screenshot use-case of the new change. The first run uses `format: docker` on the patch to Chart.yaml, which forces the - in the version. On the other hand, the second run excludes the format input, bringing back the + since that's the default preexisting behavior from using the original formatted version.

<img width="672" height="479" alt="image" src="https://github.com/user-attachments/assets/bbbf5fa9-c8dd-471a-9a4b-d80e6cbbdbff" />


## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that
apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

- [x] I have read the
      [CONTRIBUTING](https://github.com/Optum/semver-cli/blob/main/CONTRIBUTING.md)
      doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
